### PR TITLE
Update Plausible and Google Search Console tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,10 +3,10 @@
 
   {% include head.html %}
 
+  <script defer data-domain="coi.theycareforyou.org" src="https://plausible.io/js/script.js"></script>
+  <meta name="google-site-verification" content="eR1r6t1s625V5eygrmCdJmWzfFVMWx7Rgi3fY_ZzjtM" />
+
   <body>
-
-    <script data-domain="coi.theycareforyou.org" defer id="plausible" src="https://plausible.io/js/plausible.compat.js"></script>
-
     {% include header.html %}
     {{ content }}
     {% include footer.html %}


### PR DESCRIPTION
Linked to https://github.com/opensafely-core/sysadmin/issues/175

We no longer need to use the `compat` script as Internet Explorer usage has fallen below 1% of traffic.